### PR TITLE
Implemented better logging, mainly so we don't re-create Color tables…

### DIFF
--- a/gamemode/core/derma/cl_charactercreator.lua
+++ b/gamemode/core/derma/cl_charactercreator.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 local PANEL = {}
 
 function PANEL:Init()
@@ -31,7 +33,7 @@ function PANEL:Init()
         if name == false then return msg(rejectReason, "impulse", "OK") end
 
         Derma_Query("Are you sure you are finished?\nYou can edit your character later, but it will cost a fee.", "impulse", "Yes", function()
-            print("[impulse-reforged] Sending character data to server...")
+            logs.Info("Sending character data to server...")
 
             net.Start("impulseCharacterCreate")
             net.WriteString(characterName)

--- a/gamemode/core/derma/cl_craftingitem.lua
+++ b/gamemode/core/derma/cl_craftingitem.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 local bodyCol = Color(50, 50, 50, 210)
 local secCol = Color(209, 209, 209, 255)
 local noCol = Color(215, 40, 40, 255)
@@ -22,7 +24,7 @@ function PANEL:SetMix(mix)
     local item = impulse.Inventory.Items[id]
 
     if ( !item ) then
-        print("[impulse-reforged] Could not find item: " .. class .. " for use in mix: " .. mix.Class .. "!")
+        logs.Error("Could not find item: " .. class .. " for use in mix: " .. mix.Class .. "!")
         return self:Remove()
     end
 

--- a/gamemode/core/derma/cl_newsfeed.lua
+++ b/gamemode/core/derma/cl_newsfeed.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 local PANEL = {}
 
 function PANEL:Init()
@@ -14,14 +16,14 @@ function PANEL:Init()
     function(error) 
         if IsValid(self) then 
             self:Remove()
-            print("[impulse-reforged] Failed to load newsfeed. Error: "..error)
+            logs.Error("Failed to load newsfeed. Error: "..error)
         end 
     end)
 end
 
 function PANEL:SetupNews(newsData)
     if not newsData then
-        return print("[impulse-reforged] Failed to load newsfeed.")
+        return logs.Error("Failed to load newsfeed.")
     end
     
     for v,postData in pairs(newsData) do

--- a/gamemode/core/derma/cl_settings.lua
+++ b/gamemode/core/derma/cl_settings.lua
@@ -18,7 +18,7 @@ function PANEL:Init()
 
     for v, k in SortedPairs(settings) do
         if type(k) != "table" then
-            MsgC(Color(255, 0, 0), "Setting " .. v .. " is not a table, skipping...\n")
+            impulse.Logs.Debug("Setting " .. v .. " is not a table, skipping...")
             continue
         end
 

--- a/gamemode/core/derma/cl_vendor.lua
+++ b/gamemode/core/derma/cl_vendor.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 local PANEL = {}
 
 function PANEL:Init()
@@ -25,11 +27,11 @@ function PANEL:SetupVendor()
     local vendorType = npc:GetVendor()
 
     if not vendorType then
-        return print("[impulse-reforged] Vendor has no VendorType set!")
+        logs.Warning("Vendor has no VendorType set!")
     end
 
     if not impulse.Vendor.Data[vendorType] then
-        return print("[impulse-reforged] "..vendorType.." invalid.")
+        return logs.Error("VendorType "..vendorType.." is invalid!")
     end
 
     self.NPC = npc
@@ -88,14 +90,14 @@ function PANEL:SetupVendor()
             local itemid = impulse.Inventory:ClassToNetID(v)
 
             if not itemid then
-                print("[impulse-reforged] "..v.." is invalid!")
+                logs.Error(""..v.." is invalid!")
                 continue
             end
 
             local item = impulse.Inventory.Items[itemid]
 
             if not item then
-                print("[impulse-reforged] Failed to resolve ItemID "..itemid.."! (Class "..v..")!")
+                logs.Error("Failed to resolve ItemID "..itemid.."! (Class "..v..")!")
                 continue
             end
 
@@ -113,14 +115,14 @@ function PANEL:SetupVendor()
             local itemid = impulse.Inventory:ClassToNetID(v)
 
             if not itemid then
-                print("[impulse-reforged] "..v.." is invalid!")
+                logs.Error(""..v.." is invalid!")
                 continue
             end
 
             local item = impulse.Inventory.Items[itemid]
 
             if not item then
-                print("[impulse-reforged] Failed to resolve ItemID "..itemid.."! (Class "..v..")!")
+                logs.Error("Failed to resolve ItemID "..itemid.."! (Class "..v..")!")
                 continue
             end
 

--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 function GM:ForceDermaSkin()
     return "impulse"
 end
@@ -17,7 +19,7 @@ function GM:OnSchemaLoaded()
         local data = util.JSONToTable(f)
 
         if not data then
-            print("[impulse-reforged] Error loading menu message "..v.."!")
+            logs.Error("Error loading menu message "..k.."!")
             continue
         end
 

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 function GM:PlayerUseSpawnSaver(ply)
     return false
 end
@@ -6,7 +8,7 @@ function GM:DatabaseConnected()
     -- Create the SQL tables if they do not exist.
     impulse.Database:LoadTables()
 
-    MsgC(Color(0, 255, 0), "Database Type: " .. impulse.Database.Config.adapter .. ".\n")
+    logs.Database("Database type: " .. impulse.Database.Config.adapter .. ".")
 
     if ( impulse.Database.Config.dev and impulse.Database.Config.dev.preview ) then
         GetConVar("impulse_preview"):SetBool(true)
@@ -83,16 +85,16 @@ function GM:PlayerInitialSpawn(ply)
             end
 
             if ( GExtension ) then
-                MsgC(Color(0, 255, 0), "[impulse-reforged] GExtension detected, skipping group setting for '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")'.\n")
+                logs.Database("GExtension detected, skipping group setting for '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")'.")
             elseif ( VyHub ) then
-                MsgC(Color(0, 255, 0), "[impulse-reforged] VyHub detected, skipping group setting for '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")'.\n")
+                logs.Database("VyHub detected, skipping group setting for '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")'.")
             else
                 if ( db.group ) then
                     ply:SetUserGroup(db.group, true)
-                    MsgC(Color(0, 255, 0), "[impulse-reforged] Set '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")' to group '" .. db.group .. "'.\n")
+                    logs.Database("Set '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")' to group '" .. db.group .. "'.")
                 else
                     ply:SetUserGroup("user", true)
-                    MsgC(Color(255, 0, 0), "[impulse-reforged] No group found for '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")'. Defaulting to user.\n")
+                    logs.Database("No group found for '" .. ply:SteamID64() .. " (" .. ply:Name() .. ")'. Defaulting to user.")
     
                     local queryGroup = mysql:Update("impulse_players")
                     queryGroup:Update("group", "user")
@@ -639,7 +641,7 @@ end
 function GM:DoPlayerDeath(ply, attacker, dmginfo)
     local ragCount = table.Count(ents.FindByClass("prop_ragdoll"))
     if ( ragCount > 32 ) then
-        print("[impulse-reforged] Avoiding ragdoll body spawn for performance reasons... (rag count: " .. ragCount .. ")")
+        logs.Debug("Avoiding ragdoll body spawn for performance reasons... (rag count: " .. ragCount .. ")")
         return
     end
 

--- a/gamemode/core/hooks/sv_net.lua
+++ b/gamemode/core/hooks/sv_net.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 util.AddNetworkString("impulseATMDeposit")
 util.AddNetworkString("impulseATMOpen")
 util.AddNetworkString("impulseATMWithdraw")
@@ -132,7 +134,7 @@ net.Receive("impulseCharacterCreate", function(len, ply)
     query:Callback(function(result)
         -- If we already have a rp name, we can't create a new character
         if istable(result) and #result > 0 and result[1].rpname and result[1].rpname != "" then
-            MsgC(Color(255, 0, 0), "[impulse-reforged] "..ply:SteamName().." attempted to create a new character when they already have one.\n")
+            logs.Info(ply:SteamName().." attempted to create a new character when they already have one.")
             ply:Kick("You already have a character, stop trying to exploit.")
             return
         end
@@ -179,7 +181,7 @@ net.Receive("impulseCharacterCreate", function(len, ply)
                     playtime = 0
                 }
 
-                MsgC(Color(0, 255, 0), "[impulse-reforged] "..ply:SteamName().." has created their character with the name \""..charName.."\".\n")
+                logs.Debug(ply:SteamName().." has created their character with the name \""..charName.."\".")
 
                 ply:Freeze(false)
                 ply:AllowScenePVSControl(false) -- stop cutscene

--- a/gamemode/core/libs/cl_settings.lua
+++ b/gamemode/core/libs/cl_settings.lua
@@ -62,25 +62,27 @@ impulse.Settings.Stored = {}
 --         print("Textbox setting changed to: "..newVal)
 --     end
 -- })
+
+local logs = impulse.Logs
 function impulse.Settings:Define(name, settingData)
     if not settingData then
-        return MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not Define Setting. Data is nil, attempted name: "..name.."\n")
+        logs.Error("Could not Define Setting. Data is nil, attempted name: "..name)
     end
 
     if not type(settingData) == "table" then
-        return MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not Define Setting. Data is not a table, attempted name: "..name.."\n")
+        logs.Error("Could not Define Setting. Data is not a table, attempted name: "..name)
     end
 
     if not settingData.name then
-        return MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not Define Setting. Name is nil, attempted name: "..name.."\n")
+        logs.Error("Could not Define Setting. Name is nil, attempted name: "..name)
     end
 
     if not settingData.type then
-        return MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not Define Setting. Type is nil, attempted name: "..name.."\n")
+        logs.Error("Could not Define Setting. Type is nil, attempted name: "..name)
     end
 
     if settingData.default == nil then
-        return MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not Define Setting. Default is nil, attempted name: "..name.."\n")
+        logs.Error("Could not Define Setting. Default is nil, attempted name: "..name)
     end
 
     if settingData.type == "slider" then
@@ -97,7 +99,7 @@ function impulse.Settings:Define(name, settingData)
         end
     elseif settingData.type == "dropdown" then
         if not settingData.options then
-            return MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not Define Setting. Options is nil, attempted name: "..name.."\n")
+            logs.Error("Could not Define Setting. Options is nil, attempted name: "..name)
         end
     end
 
@@ -141,7 +143,7 @@ end
 function impulse.Settings:Load()
     for v, k in pairs(self.Stored) do
         if not k then
-            MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not load setting. Please contact a developer, attempted name: "..v.."\n")
+            logs.Error("Could not load setting. Please contact a developer. Attempted name: "..v)
             continue
         end
 
@@ -183,7 +185,7 @@ function impulse.Settings:Set(name, value)
         return
     end
 
-    return MsgC(Color(255, 0, 0), "[impulse-reforged] Error, could not SetSetting. Please contact a developer, attempted name: "..name.."\n")
+    return logs.Error("Could not SetSetting. Please contact a developer, attempted name: "..name)
 end
 
 concommand.Add("impulse_settings_reset", function()
@@ -191,5 +193,5 @@ concommand.Add("impulse_settings_reset", function()
         impulse.Settings:Set(v, k.default)
     end
 
-    MsgC(Color(0, 255, 0), "[impulse-reforged] Settings reset to default.\n")
+    return logs.Success("Settings reset to default.")
 end)

--- a/gamemode/core/libs/sh_logging.lua
+++ b/gamemode/core/libs/sh_logging.lua
@@ -1,0 +1,68 @@
+LOG_LEVEL_ERROR = 4 --- Only print out errors.
+LOG_LEVEL_WARNING = 3 --- Print out warnings and errors.
+LOG_LEVEL_INFO = 2 --- Print out info, warnings, and errors.
+LOG_LEVEL_DEBUG = 1 --- Print out all log levels.
+
+--- Logging utilities for the gamemode.
+-- @module impulse.Logs
+impulse.Logs = impulse.Logs or {
+    --- The header for all log messages. Typically the name of the gamemode.
+    Header = "[impulse-reforged]",
+    LogLevel = LOG_LEVEL_INFO
+}
+
+local MsgC = MsgC
+local Color = Color
+
+
+--- Colors for different log levels.
+local clrInfo = Color(125, 173, 250)
+local clrError = Color(255, 0, 0)
+local clrWarning = Color(255, 255, 0)
+local clrSuccess = Color(0, 255, 0)
+local clrDatabase = Color(115, 0, 255)
+local clrWhite = Color(255, 255, 255)
+local clrDebug = Color(150, 150, 150)
+local logHeader = impulse.Logs.Header
+
+
+--- Log an Info-level message. Used for general debug messages.`
+---@param text string The message to log.
+function impulse.Logs.Info(text)
+    if impulse.Logs.LogLevel > LOG_LEVEL_INFO then return end
+    MsgC(clrInfo, logHeader .. " [INFO] ", clrWhite, text, "\n")
+end
+
+--- Log a Debug-level message. Used for detailed debug messages.
+--- @param text string The message to log.
+function impulse.Logs.Debug(text)
+    if impulse.Logs.LogLevel > LOG_LEVEL_DEBUG then return end
+	MsgC(clrDebug, logHeader .. " [DEBUG] ", clrWhite, text, "\n")
+end
+
+--- Log an Error-level message. Used for critical errors.
+function impulse.Logs.Error(text)
+    if impulse.Logs.LogLevel > LOG_LEVEL_ERROR then return end
+	MsgC(clrError, logHeader .. " [ERROR] ", clrWhite, text, "\n")
+end
+
+--- Log a Warning-level message. Used for non-critical errors.
+---@param text string The message to log.
+function impulse.Logs.Warning(text)
+    if impulse.Logs.LogLevel > LOG_LEVEL_WARNING then return end
+	MsgC(clrWarning, logHeader .. " [WARNING] ", clrWhite, text, "\n")
+end
+
+--- Log a Success-level message. Used for successful operations.
+--- @param text string The message to log.
+function impulse.Logs.Success(text)
+    if impulse.Logs.LogLevel > LOG_LEVEL_INFO then return end
+	MsgC(clrSuccess, logHeader .. " [SUCCESS] ", clrWhite, text, "\n")
+end
+
+--- Log a Database-level message. Used for database operations.
+--- @param text string The message to log.
+function impulse.Logs.Database(text)
+    if impulse.Logs.LogLevel > LOG_LEVEL_INFO then return end
+	MsgC(clrDatabase, logHeader .. " [DB] ", clrWhite, text, "\n")
+end

--- a/gamemode/core/libs/sh_plugins.lua
+++ b/gamemode/core/libs/sh_plugins.lua
@@ -1,6 +1,8 @@
 impulse.Plugins = impulse.Plugins or {}
 impulse.Plugins.List = impulse.Plugins.List or {}
 
+local logs = impulse.Logs
+
 function impulse.Plugins:LoadEntities(path)
     local files, folders
 
@@ -90,7 +92,7 @@ function impulse.Plugins:LoadEntities(path)
 end
 
 function impulse.Plugins:Load(path)
-    MsgC(Color(83, 143, 239), "[impulse-reforged] Loading plugins...\n")
+    logs.Info("Loading plugins...")
 
     path = path or "impulse-reforged/plugins"
 
@@ -99,7 +101,7 @@ function impulse.Plugins:Load(path)
 
     for k, v in ipairs(folders) do
         if ( disabledPlugins and disabledPlugins[v] ) then
-            MsgC(Color(255, 255, 0), "[impulse-reforged] Skipping disabled plugin: " .. v .. "\n")
+            logs.Debug("Skipping disabled plugin: " .. v)
             continue
         end
 
@@ -129,7 +131,7 @@ function impulse.Plugins:Load(path)
 
     for k, v in ipairs(files) do
         if ( disabledPlugins and disabledPlugins[v] ) then
-            MsgC(Color(255, 255, 0), "[impulse-reforged] Skipping disabled plugin: " .. v .. "\n")
+            logs.Debug("Skipping disabled plugin: " .. v)
             continue
         end
 
@@ -147,5 +149,5 @@ function impulse.Plugins:Load(path)
         PLUGIN = nil
     end
 
-    MsgC(Color(0, 255, 0), "[impulse-reforged] Loaded plugins.\n")
+    logs.Success("Loaded plugins.")
 end

--- a/gamemode/core/libs/sh_schema.lua
+++ b/gamemode/core/libs/sh_schema.lua
@@ -5,6 +5,8 @@ impulse.Schema = impulse.Schema or {}
 
 SCHEMA = {}
 
+local logs =  impulse.Logs
+
 local default = {
     Name = "Unknown",
     Description = "No description available.",
@@ -16,27 +18,27 @@ local default = {
 -- @internal
 -- @usage impulse.Schema:Load() -- Called by impulse:Boot()
 function impulse.Schema:Load()
-    MsgC(Color(255, 255, 0), "[impulse-reforged] Starting schema load ...\n")
+    logs.Info("Starting schema load ...")
 
     local name = engine.ActiveGamemode()
     if ( name == "impulse-reforged" ) then
-        MsgC(Color(255, 0, 0), "[impulse-reforged] Attempted to load Schema \"impulse-reforged\", aborting. This is the framework!\n")
+        logs.Error("Attempted to load Schema \"impulse-reforged\", aborting. This is the framework!")
         SetGlobalString("impulse_fatalerror", "Failed to load Schema \"impulse-reforged\", aborting. This is the framework!")
         return
     end
 
-    MsgC(Color(83, 143, 239), "[impulse-reforged] Loading \"" .. name .. "\" schema...\n")
+    logs.Info("Loading Schema \"" .. name .. "\"...")
 
     if ( SERVER and !file.IsDir(name, "LUA") ) then
         SetGlobalString("impulse_fatalerror", "Failed to load Schema \"" .. name .. "\", does not exist.")
-        MsgC(Color(255, 0, 0), "[impulse-reforged] Failed to load Schema \"" .. name .. "\", does not exist.\n")
+        logs.Error("Failed to load Schema \"" .. name .. "\", does not exist.")
         return
     end
 
     local path = name .. "/schema/sh_schema.lua"
     if ( !file.Exists(path, "LUA") ) then
         SetGlobalString("impulse_fatalerror", "Failed to load Schema \"" .. name .. "\", no sh_schema.lua found.")
-        MsgC(Color(255, 0, 0), "[impulse-reforged] Failed to load Schema \"" .. name .. "\", no sh_schema.lua found.\n")
+        logs.Error("Failed to load Schema \"" .. name .. "\", no sh_schema.lua found.")
         return
     end
 
@@ -66,10 +68,10 @@ function impulse.Schema:Load()
     local map = game.GetMap()
     path = name .. "/schema/config/maps/" .. map .. ".lua"
     if ( file.Exists(path, "LUA") ) then
-        MsgC(Color(0, 255, 0), "[impulse-reforged] Loading map config for \"" .. map .. "\" in Schema \"" .. name .. "\".\n")
+        logs.Info("Loading map config for \"" .. map .. "\" in Schema \"" .. name .. "\".")
         impulse.Util:Include(path, "shared")
     else
-        MsgC(Color(255, 0, 0), "[impulse-reforged] Failed to find map config for \"" .. map .. "\" in Schema \"" .. name .. "\".\n")
+        logs.Error("Failed to find map config for \"" .. map .. "\" in Schema \"" .. name .. "\".")
     end
 
     hook.Run("PostConfigLoad")
@@ -89,7 +91,7 @@ function impulse.Schema:Load()
 
     hook.Run("OnSchemaLoaded")
 
-    MsgC(Color(0, 255, 0), "[impulse-reforged] Schema \"" .. name .. "\" loaded successfully.\n")
+    logs.Success("Schema \"" .. name .. "\" loaded successfully.")
 end
 
 --- Boots a specified object from a foreign schema using the piggbacking system
@@ -98,7 +100,7 @@ end
 -- @string object The folder in the schema to load
 -- @usage impulse.Schema:PiggyBoot("impulse-hl2rp", "items")
 function impulse.Schema:PiggyBoot(schema, object)
-    MsgC(Color(83, 143, 239), "[impulse-reforged] [" .. schema .. "] Loading " .. object .. " (via PiggyBoot)\n")
+    logs.Info("[" .. schema .. "] Loading " .. object .. " (via PiggyBoot)")
     impulse.Util:IncludeDir(schema .. "/" .. object)
 end
 
@@ -108,6 +110,6 @@ end
 -- @string plugin The plugin folder name
 -- @usage impulse.Schema:PiggyBootPlugin("impulse-hl2rp", "pluginname")
 function impulse.Schema:PiggyBootPlugin(schema, plugin)
-    MsgC(Color(83, 143, 239), "[impulse-reforged] [" .. schema .. "] [plugins] Loading plugin (via PiggyBoot) \"" .. plugin .. "\"\n")
+    logs.Info("[" .. schema .. "] [plugins] Loading plugin (via PiggyBoot) \"" .. plugin .. "\"")
     self:LoadPlugin(schema .. "/plugins/" .. plugin, plugin)
 end

--- a/gamemode/core/libs/sv_conutil.lua
+++ b/gamemode/core/libs/sv_conutil.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 local function IsSteamID(str)
     return string.match(str, "STEAM_%d:%d:%d+")
 end
@@ -10,20 +12,20 @@ concommand.Add("impulse_set_group", function(ply, cmd, args)
     if ( !IsValid(ply) or ply:IsSuperAdmin() or ply:IsListenServerHost() ) then
         local find = args[1]
         if !find then
-            MsgC(Color(255, 0, 0), "[impulse-reforged] No player target specified.\n")
+            logs.Error("No player target specified.")
             return
         end
 
         local group = args[2]
         if !group then
-            MsgC(Color(255, 0, 0), "[impulse-reforged] No group specified.\n")
+            logs.Error("No group specified.")
             return
         end
 
         local targ = impulse.Util:FindPlayer(find)
         if IsValid(targ) then
             targ:SetUserGroup(group, true)
-            MsgC(Color(83, 143, 239), "[impulse-reforged] Set '" .. targ:SteamID64() .. " (" .. targ:Name() .. ")' to group '" .. group .. "'.\n")
+            logs.Info("Set '" .. targ:SteamID64() .. " (" .. targ:Name() .. ")' to group '" .. group .. "'.\n")
 
             local query = mysql:Update("impulse_players")
             query:Update("group", group)
@@ -32,7 +34,7 @@ concommand.Add("impulse_set_group", function(ply, cmd, args)
 
             return
         else
-            MsgC(Color(255, 200, 0), "[impulse-reforged] Target not found, checking for SteamID64...\n")
+            logs.Warning("Target not found, checking for SteamID64...\n")
         end
 
         local steamid
@@ -43,7 +45,7 @@ concommand.Add("impulse_set_group", function(ply, cmd, args)
         end
         
         if !steamid then
-            MsgC(Color(255, 0, 0), "[impulse-reforged] Target not found, and '" .. find .. "' is not a valid SteamID64.\n")
+            logs.Error("Target not found, and '" .. find .. "' is not a valid SteamID64.")
             return
         end
 
@@ -52,6 +54,6 @@ concommand.Add("impulse_set_group", function(ply, cmd, args)
         query:Where("steamid", steamid)
         query:Execute()
 
-        MsgC(Color(83, 143, 239), "[impulse-reforged] Set '" .. steamid .. "' to group '" .. group .. "'.\n")
+        logs.Success("Set '" .. steamid .. "' to group '" .. group .. "'.\n")
     end
 end)

--- a/gamemode/core/libs/sv_database.lua
+++ b/gamemode/core/libs/sv_database.lua
@@ -1,5 +1,6 @@
 --- Database library for impulse, ported directly from Helix.
 -- @module impulse.Database
+local logs = impulse.Logs
 
 impulse.Database = impulse.Database or {
     Schema = {},
@@ -87,9 +88,8 @@ end
 -- @realm server
 -- @internal
 function impulse.Database:LoadTables()
-    MsgC(Color(255, 255, 0), "[impulse-reforged] [database] loading tables...\n")
-
     local query
+    logs.Database("loading tables...")
 
     query = mysql:Create("impulse_schema")
         query:Create("table", "VARCHAR(64) NOT NULL")
@@ -198,7 +198,7 @@ function impulse.Database:LoadTables()
         end)
     query:Execute()
 
-    MsgC(Color(0, 255, 0), "[impulse-reforged] [database] tables loaded.\n")
+    logs.Database("tables loaded.")
 end
 
 --- Wipes all tables in the database, meaning all data will be lost.
@@ -262,17 +262,17 @@ concommand.Add("impulse_database_reset", function(ply, cmd, arguments)
         if ( resetCalled < RealTime() ) then
             resetCalled = RealTime() + 3
 
-            MsgC(Color(255, 0, 0), "[impulse] WIPING THE DATABASE WILL PERMENANTLY REMOVE ALL PLAYER, CHARACTER, ITEM, AND INVENTORY DATA.\n")
-            MsgC(Color(255, 0, 0), "[impulse] THE SERVER WILL RESTART TO APPLY THESE CHANGES WHEN COMPLETED.\n")
-            MsgC(Color(255, 0, 0), "[impulse] TO CONFIRM DATABASE RESET, RUN 'impulse_database_reset' AGAIN WITHIN 3 SECONDS.\n")
+            logs.Error("WIPING THE DATABASE WILL PERMENANTLY REMOVE ALL PLAYER, CHARACTER, ITEM, AND INVENTORY DATA.")
+            logs.Error("THE SERVER WILL RESTART TO APPLY THESE CHANGES WHEN COMPLETED.")
+            logs.Error("TO CONFIRM DATABASE RESET, RUN 'impulse_database_reset' AGAIN WITHIN 3 SECONDS.")
         else
             resetCalled = 0
-            MsgC(Color(255, 0, 0), "[impulse] DATABASE WIPE IN PROGRESS...\n")
+            logs.Error("DATABASE WIPE IN PROGRESS...")
 
             hook.Run("OnWipeTables")
 
             impulse.Database:WipeTables(function()
-                MsgC(Color(255, 255, 0), "[impulse] DATABASE WIPE COMPLETED!\n")
+                logs.Warning("DATABASE WIPE COMPLETED! RESTARTING SERVER...")
                 RunConsoleCommand("changelevel", game.GetMap())
             end)
         end

--- a/gamemode/core/libs/sv_doors.lua
+++ b/gamemode/core/libs/sv_doors.lua
@@ -1,6 +1,7 @@
 impulse.Doors = impulse.Doors or {}
 impulse.Doors.Data = impulse.Doors.Data or {}
 
+local logs = impulse.Logs
 local eMeta = FindMetaTable("Entity")
 local fileName = "impulse-reforged/doors/"..game.GetMap()
 
@@ -21,8 +22,8 @@ function impulse.Doors:Save()
             end
         end
     end
-
-    print("[impulse-reforged] Saving doors to impulse-reforged/doors/"..game.GetMap()..".json | Doors saved: "..#doors)
+    
+    logs.Debug("Saving doors to impulse-reforged/doors/"..game.GetMap()..".json | Doors saved: "..#doors)
     file.Write(fileName..".json", util.TableToJSON(doors))
 end
 
@@ -73,7 +74,7 @@ function impulse.Doors:Load()
                 if doorData.group then doorEnt:SetNetVar("doorGroup", doorData.group) end
                 if doorData.buyable != nil then doorEnt:SetNetVar("doorBuyable", false) end
 
-                print("[impulse-reforged] Warning! Added door by HammerID value because it could not be found via pos. Door index: "..doorIndex..". Please investigate.")
+                logs.Warning("Added door by HammerID value because it could not be found via pos. Door index: "..doorIndex..". Please investigate.")
             end
         end
 

--- a/gamemode/core/libs/sv_inventory.lua
+++ b/gamemode/core/libs/sv_inventory.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 --- Allows interactions with the players inventory
 -- @module impulse.Inventory
 
@@ -111,7 +113,7 @@ end
 -- @treturn entity Spawned item
 function impulse.Inventory:SpawnItem(class, pos, bannedPlayer, killTime)
     local itemID = impulse.Inventory:ClassToNetID(class)
-    if not itemID then return print("[impulse-reforged] Attempting to spawn nil item!") end
+    if not itemID then return logs.Error("Attempting to spawn nil item!") end
     
     local item = ents.Create("impulse_item")
     item:SetItem(itemID)
@@ -138,7 +140,7 @@ end
 -- @treturn entity Spawned workbench
 function impulse.Inventory:SpawnBench(class, pos, ang)
     local benchClass = impulse.Inventory.Benches[class]
-    if not benchClass then return print("[impulse-reforged] Attempting to spawn nil bench!") end
+    if not benchClass then return logs.Error("Attempting to spawn nil bench!") end
 
     local bench = ents.Create("impulse_bench")
     bench:SetBench(benchClass)

--- a/gamemode/core/libs/sv_loot.lua
+++ b/gamemode/core/libs/sv_loot.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 impulse.Loot = impulse.Loot or {}
 
 local ANTICRASH_ATTEMPTS = 0
@@ -32,7 +34,7 @@ function impulse.Loot.GenerateFromPool(pool)
         ANTICRASH_ATTEMPTS = ANTICRASH_ATTEMPTS + 1
 
         if ANTICRASH_ATTEMPTS > 32 then
-            print("[impulse-reforged] HIGH LOOT GENERATION ATTEMPTS WARNING! ("..pool..") ("..ANTICRASH_ATTEMPTS..")")
+            logs.Warning("HIGH LOOT GENERATION ATTEMPTS WARNING! ("..pool..") ("..ANTICRASH_ATTEMPTS..")")
             print("Please make sure this lootpool is NOT impossible to compute!")    
         end
 

--- a/gamemode/core/libs/sv_save.lua
+++ b/gamemode/core/libs/sv_save.lua
@@ -6,6 +6,8 @@ impulse.Save = impulse.Save or {}
 file.CreateDir("impulse-reforged")
 file.CreateDir("impulse-reforged/saves")
 
+
+local logs = impulse.Logs
 function impulse.Save:Load()
     local map = string.lower(game.GetMap())
     if ( file.Exists("impulse-reforged/saves/" .. map .. ".json", "DATA") ) then
@@ -13,7 +15,7 @@ function impulse.Save:Load()
         for k, v in pairs(savedEnts) do
             local ent = ents.Create(v.class)
             if ( !IsValid(ent) ) then
-                print("[impulse-reforged] [save] Entity " .. v.class .. " does not exist! Skipping!")
+                logs.Error("[save] Entity " .. v.class .. " does not exist! Skipping!")
                 continue
             end
 

--- a/plugins/ops_eventmanager/cl_net.lua
+++ b/plugins/ops_eventmanager/cl_net.lua
@@ -1,3 +1,5 @@
+local logs = impulse.Logs
+
 net.Receive("impulseOpsEMMenu", function()
     local count = net.ReadUInt(8)
     local svSequences = {}
@@ -46,7 +48,7 @@ net.Receive("impulseOpsEMPlayScene", function()
     local scene = net.ReadString()
 
     if not impulse.Ops.EventManager.Scenes[scene] then
-        return print("[impulse-reforged] Error! Can't find sceneset: "..scene)
+        return logs.Error("Can't find sceneset: "..scene)
     end
 
     impulse.Scenes.PlaySet(impulse.Ops.EventManager.Scenes[scene])


### PR DESCRIPTION
I realized by accident that the framework has a bunch of MsgC calls to act as console logs, with each one creating it's own colour every time. This felt sketchy so I added a new module:
impulse.Logs
within the module, you can define the logging level and changing the colors and tags is also quite simple.